### PR TITLE
Adding data_url as parameter in case the user wants to share a different url

### DIFF
--- a/SocialShareButton.php
+++ b/SocialShareButton.php
@@ -35,6 +35,11 @@ class SocialShareButton extends CInputWidget
 	
 	public $networks = array('facebook','googleplus','linkedin','twitter');
 
+	
+	/**
+	 * @var string url to share
+	 */
+	public $data_url = Yii::app()->createAbsoluteUrl(Yii::app()->request->url);
 
 	/**
 	 * The extension initialisation

--- a/views/facebook.php
+++ b/views/facebook.php
@@ -14,4 +14,4 @@
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
 
-<div class="fb-share-button" data-href="<?php echo Yii::app()->createAbsoluteUrl(Yii::app()->request->url); ?>" data-width="200" data-type="<?=$data_type?>"></div>
+<div class="fb-share-button" data-href="<?=$this->data_url?>" data-width="200" data-type="<?=$data_type?>"></div>

--- a/views/googleplus.php
+++ b/views/googleplus.php
@@ -5,7 +5,7 @@
 		$data_type = 'bubble';
 ?>
 
-<div class="g-plus" data-href="<?php echo Yii::app()->createAbsoluteUrl(Yii::app()->request->url); ?>" data-action="share" data-annotation="<?=$data_type?>"></div>
+<div class="g-plus" data-href="<?=$this->data_url?>" data-action="share" data-annotation="<?=$data_type?>"></div>
 
 <script type="text/javascript">
   (function() {

--- a/views/linkedin.php
+++ b/views/linkedin.php
@@ -8,4 +8,4 @@
 <script src="//platform.linkedin.com/in.js" type="text/javascript">
   lang: en_US
 </script>
-<script type="IN/Share" data-url="<?php echo Yii::app()->createAbsoluteUrl(Yii::app()->request->url); ?>" data-counter="right"></script>
+<script type="IN/Share" data-url="<?=$this->data_url?>" data-counter="right"></script>

--- a/views/twitter.php
+++ b/views/twitter.php
@@ -1,3 +1,3 @@
-<a href="https://twitter.com/share" class="twitter-share-button" data-url="<?php echo Yii::app()->createAbsoluteUrl(Yii::app()->request->url); ?>" data-via="<?=$this->data_via?>" data-lang="en" data-count="<?=$this->style?>">Tweet</a>
+<a href="https://twitter.com/share" class="twitter-share-button" data-url="<?=$this->data_url?>" data-via="<?=$this->data_via?>" data-lang="en" data-count="<?=$this->style?>">Tweet</a>
 
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>


### PR DESCRIPTION
Sometimes a user is viewing in a private view of a certain record, which cannot be accessed unless logged in. In those cases, sharing the current url would not be as meaningful as sharing the public url. With these changes the developer may add a data_url parameter to share a different url than the current one.
